### PR TITLE
chore(deps): update pnpm to v11 and drop Node 20 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        node-version: ["20", "22"]
+        node-version: ["22", "24"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "node-red-contrib-say",
   "version": "0.4.0",
   "description": "Output node for node-red for TTS (text to speech). Requires preinstall TTS program on command line.",
-  "packageManager": "pnpm@10.34.5",
+  "packageManager": "pnpm@11.21.0",
   "main": "say.js",
   "scripts": {
     "test": "SAY_TEST_MODULE=test/mocks/say.js node --test test/say.test.js",
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/programmerqeu/node-red-contrib-say",
   "engines": {
-    "node": ">=18"
+    "node": ">=22.13"
   },
   "dependencies": {
     "say": "^0.16.0"


### PR DESCRIPTION
## Summary

- Bumps the `packageManager` pin from `pnpm@10.34.5` to `pnpm@11.21.0` (same version originally proposed in #23).
- Raises `engines.node` from `>=18` to `>=22.13`, since pnpm v11 requires Node.js ≥22.13 and fails immediately on older runtimes (`ERR_UNKNOWN_BUILTIN_MODULE: node:sqlite`).
- Drops Node 20 from the CI test matrix (now `["22", "24"]`), since it can no longer install/run under pnpm v11.

## Why not just merge #23?

#23 (Renovate) only bumped the pnpm version and failed CI on Node 20/macOS and Node 20/Ubuntu, because the repo's `engines.node` (`>=18`) and CI matrix still included Node 20, which pnpm v11 does not support. This PR carries the same dependency bump plus the compatibility fixes so CI passes cleanly. #23 has been closed as superseded.

## Test plan

- [ ] CI passes on Node 22 and 24 (ubuntu + macos)
- [ ] `pnpm install --frozen-lockfile` succeeds
- [ ] `pnpm lint` and `pnpm test` pass

---
_Generated by [Claude Code](https://claude.ai/code/session_019LRW4Z921qtTHZahwFF5ig)_