### PR TITLE
chore(release): show all commit categories in release-please changelog

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,20 @@
 {
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
   "packages": {
     ".": {}
-  }
+  },
+  "changelog-sections": [
+    { "type": "feat", "section": "Features" },
+    { "type": "fix", "section": "Bug Fixes" },
+    { "type": "perf", "section": "Performance Improvements" },
+    { "type": "revert", "section": "Reverts" },
+    { "type": "docs", "section": "Documentation", "hidden": false },
+    { "type": "style", "section": "Styles", "hidden": false },
+    { "type": "chore", "section": "Miscellaneous Chores", "hidden": false },
+    { "type": "refactor", "section": "Code Refactoring", "hidden": false },
+    { "type": "test", "section": "Tests", "hidden": false },
+    { "type": "build", "section": "Build System", "hidden": false },
+    { "type": "ci", "section": "Continuous Integration", "hidden": false }
+  ]
 }


### PR DESCRIPTION
## Summary

- Adds an explicit `changelog-sections` list to `release-please-config.json`.
- release-please's built-in defaults hide `docs`, `style`, `chore`, `refactor`, `test`, `build`, and `ci` commits from the changelog/release PR — only `feat`/`fix`/`perf`/`revert` were shown.
- All categories are now set to `"hidden": false`, so every conventional-commit type appears in the generated release PR and `CHANGELOG.md`.

## Test plan

- [ ] Merge a commit of a previously-hidden type (e.g. `chore: ...`) and confirm it shows up under "Miscellaneous Chores" in the next release-please PR

---
_Generated by [Claude Code](https://claude.ai/code/session_019LRW4Z921qtTHZahwFF5ig)_