### PR TITLE
fix(ci): bump npm-publish workflow to Node 22

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
       - name: Setup pnpm


### PR DESCRIPTION
## Summary

- `node-red-contrib-say-v0.4.1` was released on GitHub, but never published to npm (still at 0.4.0 on the registry).
- The `npm-publish.yml` workflow pins Node 20, while pnpm was bumped to v11.21.0 in #24, which requires Node.js ≥22.13. `pnpm install --frozen-lockfile` fails immediately with `ERR_UNKNOWN_BUILTIN_MODULE: node:sqlite` (same root cause as the CI matrix fix, just in a workflow I missed updating).
- Bumps `node-version` from `"20"` to `"22"` so the publish step can actually run.

## Test plan

- [ ] Merge, then manually re-run the failed "NPM Publish" job for the `node-red-contrib-say-v0.4.1` release so 0.4.1 lands on npm

---
_Generated by [Claude Code](https://claude.ai/code/session_019LRW4Z921qtTHZahwFF5ig)_