### PR TITLE
fix(ci): allow manually re-triggering npm publish for a tag

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,6 +3,11 @@ name: NPM Publish
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish (e.g. node-red-contrib-say-v0.4.1)"
+        required: true
 
 jobs:
   publish:
@@ -11,7 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

- #27 fixed the Node version pin in `npm-publish.yml`, but re-running the failed `v0.4.1` publish job still failed with the old Node 20 error — `release`-triggered runs are pinned to the workflow file as it existed at that release's tag, so a re-run always replays the stale definition and can never pick up a later fix on `main`.
- Adds a `workflow_dispatch` trigger with a `tag` input, so the current (fixed) workflow definition can be run on demand against an already-published release tag.

## Test plan

- [ ] Merge, then manually run this workflow via **Actions → NPM Publish → Run workflow**, with `tag` set to `node-red-contrib-say-v0.4.1`, to get 0.4.1 published to npm

---
_Generated by [Claude Code](https://claude.ai/code/session_019LRW4Z921qtTHZahwFF5ig)_