### PR TITLE
docs: update Node.js compatibility in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This makes it easy to:
 | | Version |
 | --- | --- |
 | **Supported Node-RED** | **4.x** (recommended; aligned with current Node-RED releases) |
-| **Node.js** | **18.x or newer** (CI tests **20** and **22** on Ubuntu and macOS) |
+| **Node.js** | **22.13 or newer** (CI tests **22** and **24** on Ubuntu and macOS) |
 
 Older Node-RED or Node.js versions may still work but are not covered by automated tests.
 


### PR DESCRIPTION
## Summary

- `engines.node` and the CI matrix were raised to `>=22.13` (pnpm v11 requires it), but the README's Compatibility table still said "18.x or newer" and listed CI testing "20 and 22".
- Updates the table to "22.13 or newer" and "22 and 24" to match the current `package.json` / `ci.yml`.

---
_Generated by [Claude Code](https://claude.ai/code/session_019LRW4Z921qtTHZahwFF5ig)_