### PR TITLE
docs: add AGENTS.md with Node.js version sync rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# Agent Notes
+
+Guidance for AI coding agents (and contributors) working in this repository.
+
+## Keep Node.js version references in sync
+
+`engines.node` in `package.json` is the source of truth for the minimum supported Node.js version. When it changes — for example after bumping `pnpm` to a major version that raises its own Node.js requirement — update every other place that states a Node.js version **in the same PR**:
+
+- `README.md` — the Compatibility table
+- CI workflow files under `.github/workflows/` — `node-version` / matrix values
+
+This drifted out of sync after the pnpm v11 bump (`engines.node` went to `>=22.13`, but the README still said "18.x or newer" and listed the old CI matrix), which needed a separate follow-up PR to fix.


### PR DESCRIPTION
## Summary

Adds `AGENTS.md` documenting a rule for future agents/contributors: when `engines.node` changes, update the README's Compatibility table and CI workflow matrices in the same PR. This codifies the fix from #30, where the pnpm v11 bump raised `engines.node` to `>=22.13` but the README kept advertising 18.x/old CI versions until a separate follow-up PR caught it.

---
_Generated by [Claude Code](https://claude.ai/code/session_019LRW4Z921qtTHZahwFF5ig)_